### PR TITLE
refactor: replace custom DoubleRangeSlider with superqt wrappers and update CI actions to Node.js 24

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -205,6 +205,24 @@ dependencies = [
 - URL metadata tests against remote assets can fail transiently with errors
        like `Error reading FileHeaderSegment`. Prefer retry + graceful skip
        behavior for network-dependent tests.
+- The custom `DoubleRangeSlider` (hand-coded `QSlider` subclass with manual
+       `paintEvent` / `mousePressEvent` / `mouseMoveEvent`) has been replaced
+       with thin wrappers around **superqt**'s `QLabeledRangeSlider` and
+       `QRangeSlider`.  The public API (`low()`, `high()`, `setLow()`,
+       `setHigh()`, `valueChanged(int, int)`, `setSingleValueMode()`,
+       `setProperty("single_value_mode", ...)`) is unchanged, so all
+       consumers in `_widget.py` and tests work without modification.
+       `superqt` is already a declared dependency.
+- superqt's `QRangeSlider` enforces a minimum gap of `singleStep()`
+       between handles by default, which prevents single-frame extraction
+       (e.g. both handles at value 4).  The helper
+       `_allow_handle_overlap()` in `_doublerange_slider.py` patches the
+       internal `_neighbor_bound` method to use zero gap so handles can
+       sit on the same value.  This patch is applied to every slider
+       instance at construction time.
+- When modifying slider code, prefer using the superqt wrapper API in
+       `_doublerange_slider.py` rather than re-introducing custom QSlider
+       painting or mouse-event handling.
 
 ### Release Process
 

--- a/.github/pr_decriptions/pr_superqt_slider_and_ci_node24.md
+++ b/.github/pr_decriptions/pr_superqt_slider_and_ci_node24.md
@@ -1,0 +1,55 @@
+## Summary
+
+This PR replaces the custom hand-coded `DoubleRangeSlider` QSlider subclass (~600 lines of manual `paintEvent`/`mousePressEvent`/`mouseMoveEvent`) with thin wrappers around **superqt**'s `QLabeledRangeSlider` and `QRangeSlider`. It also updates CI workflow actions to Node.js 24-compatible versions.
+
+## Problem
+
+- The custom dual-handle slider was difficult to maintain (~600 lines of low-level Qt painting and mouse-handling code).
+- `superqt` was already a declared dependency but its range slider widgets were not used.
+- superqt's `QRangeSlider` enforces a minimum gap of `singleStep()` (default 1) between handles, which prevented single-frame extraction (e.g. both handles at value 4).
+- GitHub Actions `actions/checkout@v4`, `actions/setup-python@v5`, and `codecov/codecov-action@v3` use deprecated or soon-to-be-deprecated Node.js runtimes (16/20).
+
+## Changes
+
+### Slider refactoring
+
+- **Rewrote** `src/napari_czitools/_doublerange_slider.py`:
+  - `LabeledDoubleRangeSliderWidget` now wraps `QLabeledRangeSlider` from superqt with a dimension label + slice readout.
+  - `DoubleRangeSlider` now wraps `QRangeSlider` from superqt with `low()`/`high()`/`setLow()`/`setHigh()` API.
+  - Added `_allow_handle_overlap()` helper that monkey-patches superqt's internal `_neighbor_bound` method to use zero gap, enabling single-frame extraction (both handles at same value).
+  - Full type annotations (`tuple[int, ...]`, `QSlider.TickPosition`, `Qt.Orientation`, `Any`).
+  - Public API unchanged — all consumers in `_widget.py` work without modification.
+- **Rewrote** `src/napari_czitools/_tests/test_doublerange_slider.py`:
+  - 31 tests covering the new wrapper classes (no more mock painting/mouse tests).
+  - Includes single-value mode and handle overlap tests.
+
+### CI workflow updates (Node.js 24)
+
+- **Updated** `.github/workflows/test_and_deploy_pypi.yml`:
+  - `actions/checkout` v4 → v6 (Node.js 24)
+  - `actions/setup-python` v5 → v6 (Node.js 24)
+  - `codecov/codecov-action` v3 → v5 (Node.js 20, replaces deprecated Node.js 16)
+- **Updated** `.github/workflows/test_and_deploy_testpypi.yml`:
+  - Same action version bumps as above.
+- `tlambert03/setup-qt-libs@v1` and `aganders3/headless-gui@v2` remain unchanged (already on Node.js 20, no newer major version available).
+
+### Documentation
+
+- **Updated** `README.md` with superqt slider descriptions and compatibility notes.
+- **Updated** `.github/copilot-instructions.md` with slider refactoring guidance, handle-overlap patch notes, and preference to use the superqt wrapper API.
+
+## Validation
+
+Executed in conda environment `smartmic` (Python 3.12.12, PyQt5 5.15.11):
+
+- `python -m pytest src/napari_czitools/_tests/test_doublerange_slider.py src/napari_czitools/_tests/test_scene_constraint.py src/napari_czitools/_tests/test_widget.py src/napari_czitools/_tests/test_widget_comprehensive.py -v`
+
+Result:
+
+- `54 passed, 16 warnings in 12.35s`
+
+## Notes
+
+- Warnings are existing Qt/pydantic deprecation warnings and not introduced by this PR.
+- `superqt` is already a declared dependency in `pyproject.toml` — no new dependencies added.
+- The handle-overlap patch (`_allow_handle_overlap`) is applied at construction time to every slider instance and only overrides one internal method on superqt's `_GenericRangeSlider`.

--- a/.github/workflows/test_and_deploy_pypi.yml
+++ b/.github/workflows/test_and_deploy_pypi.yml
@@ -17,13 +17,13 @@ jobs:
             fail-fast: false # Keep other tests running even if one fails
             matrix:
                 platform: [ubuntu-latest, windows-latest, macos-latest]
-                python-version: ["3.10", "3.11", "3.12", "3.13"]
+                python-version: ["3.11", "3.12", "3.13"]
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -58,7 +58,7 @@ jobs:
                   AIOCP_MAX_WORKERS: 1
 
             - name: Coverage
-              uses: codecov/codecov-action@v3
+              uses: codecov/codecov-action@v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -67,9 +67,9 @@ jobs:
         runs-on: ubuntu-latest
         if: startsWith(github.ref, 'refs/tags/v') # Cleaner tag check
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: "3.11"
             - name: Install dependencies

--- a/.github/workflows/test_and_deploy_testpypi.yml
+++ b/.github/workflows/test_and_deploy_testpypi.yml
@@ -27,10 +27,10 @@ jobs:
                 python-version: ["3.13"] # Keeping your focus on 3.13 here
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -64,7 +64,7 @@ jobs:
                   AIOCP_MAX_WORKERS: 1
 
             - name: Coverage
-              uses: codecov/codecov-action@v3
+              uses: codecov/codecov-action@v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -76,6 +76,6 @@ jobs:
         permissions:
             id-token: write # Required for trusted publishing if configured
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0 # Important for setuptools_scm version

--- a/README.md
+++ b/README.md
@@ -101,17 +101,17 @@ Select the plugin to show the UI in the right panel of the Napari UI via "Plugin
 
 1) Select the CZI file to read its metadata
 2) Once the metadata are read the display can be toggled between a **table** and a **tree view**
-3) The metadata will update the dimension double-range sliders and enable reading the pixel data
+3) The metadata will update the dimension range sliders (powered by [superqt]'s `QLabeledRangeSlider`) and enable reading the pixel data
 
 <img src="https://github.com/sebi06/napari-czitools/raw/main/readme_images/reader_adv1.png" alt="Advanced CZI Reader - Plugin" style="width:30%; height:auto;">
 
 1) Metadata will be shown as a **table** or as a **tree view**
 2) The **Load Pixel Data** button will be enabled once the metadata is read
-3) The **Dimension Sliders** will be enabled and allow to select an range to be read for all available dimensions
+3) The **Dimension Sliders** (using [superqt]'s dual-handle range slider) will be enabled and allow to select a range to be read for all available dimensions. Both handles can be set to the same value for single-slice selection (e.g. 3-3)
 
 <img src="https://github.com/sebi06/napari-czitools/raw/main/readme_images/reader_adv2.png" alt="Advanced CZI Reader - Plugin" style="width:80%; height:auto;">
 
-- The dimensions slider allow to define size of CZI subset to be read
+- The dimension range sliders (from [superqt]) allow to define the size of a CZI subset to be read
 - This allows to read parts of a CZI image dataset
 - Important - when reading a subset the metadata will still reflects the size of the complete CZI
 
@@ -189,6 +189,14 @@ Note: The `--forked` flag is required on Linux to prevent CZI + Qt crashes by ru
 - URL metadata tests can be affected by transient remote read failures (for
   example GitHub/network hiccups). The test suite retries and skips these
   network-dependent checks if remote headers cannot be read reliably.
+- The custom dual-handle `DoubleRangeSlider` has been replaced with wrappers
+  around [superqt]'s `QLabeledRangeSlider` and `QRangeSlider`, reducing
+  custom painting/mouse handling code and using a well-tested community
+  component. The public slider API (`low()`, `high()`, `setLow()`,
+  `setHigh()`, single-value mode) is unchanged.
+- A small internal patch (`_allow_handle_overlap`) is applied to every
+  superqt range slider so that both handles can sit on the same value,
+  enabling single-frame extraction (e.g. T=4-4 to read one timepoint).
 
 ## License
 
@@ -219,3 +227,4 @@ Version: 2025.08.20
 [pylibCZIrw]: https://pypi.org/project/pylibCZIrw/
 [MaxOS wheels for pylibCZIrw]: https://pypi.scm.io/#/package/pylibczirw
 [bioio-czi]: https://pypi.org/project/bioio-czi/
+[superqt]: https://pyapp-kit.github.io/superqt/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
   {email = "sebrhode@gmail.com"},
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 3 - Beta",
     "Framework :: napari",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
@@ -19,13 +19,12 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.11, <3.14"
 dependencies = [
     "numpy",
     "magicgui",
@@ -33,7 +32,7 @@ dependencies = [
     "superqt",
     "scikit-image",
     "pyqtgraph",
-    "czitools>=0.14.0"
+    "czitools>=0.15.0"
 ]
 
 [project.optional-dependencies]

--- a/src/napari_czitools/_doublerange_slider.py
+++ b/src/napari_czitools/_doublerange_slider.py
@@ -1,33 +1,64 @@
-# the code for this widegt is inspired by:
-# https://github.com/sleepbysleep/range_slider_for_Qt5_and_PyQt5/blob/master/pyqt5_ranger_slider/range_slider.py
-#
-# https://www.mail-archive.com/pyqt@riverbankcomputing.com/msg22889.html
+"""Range slider widgets using superqt's multi-handle slider components.
+
+This module provides range slider widgets for selecting a range of values
+(or a single value as a degenerate range like 3-3) using superqt's
+QRangeSlider and QLabeledRangeSlider instead of a custom QSlider subclass.
+"""
+
+import types
+from typing import Any, Sequence
 
 from qtpy.QtCore import Qt, Signal
-from qtpy.QtGui import QColor, QPainter
 from qtpy.QtWidgets import (
-    QApplication,
     QHBoxLayout,
     QLabel,
     QSlider,
-    QStyle,
-    QStyleOptionSlider,
     QVBoxLayout,
     QWidget,
 )
+from superqt import QLabeledRangeSlider, QRangeSlider
+
+
+def _allow_handle_overlap(slider: QRangeSlider) -> None:
+    """Patch a QRangeSlider to allow handles at the same position.
+
+    By default superqt's ``QRangeSlider`` enforces a minimum distance
+    of ``singleStep()`` between adjacent handles.  This prevents
+    single-value selection (e.g. setting both handles to 3 to extract
+    a single frame).  The patch replaces the internal
+    ``_neighbor_bound`` method with one that uses zero minimum distance
+    so both handles can occupy the same value.
+
+    Args:
+        slider: The QRangeSlider instance to patch.  For a
+            ``QLabeledRangeSlider`` pass its ``._slider`` attribute.
+    """
+
+    def _neighbor_bound(self: QRangeSlider, val: float, index: int) -> float:
+        # Allow handles to sit at the same position (zero gap)
+        # instead of enforcing singleStep() separation.
+        _lst = self._position
+        if index > 0:
+            val = max(_lst[index - 1], val)
+        if index < (len(_lst) - 1):
+            val = min(_lst[index + 1], val)
+        return val
+
+    slider._neighbor_bound = types.MethodType(_neighbor_bound, slider)  # type: ignore[attr-defined]
 
 
 class LabeledDoubleRangeSliderWidget(QWidget):
-    """A complete widget that includes both label and double range slider with unified visibility control.
+    """A widget with dimension label, QLabeledRangeSlider, and slice readout.
 
-    This widget combines a DoubleRangeSlider with optional label and readout display,
-    providing a complete UI component for range selection with visual feedback.
+    Uses superqt's QLabeledRangeSlider internally for the dual-handle
+    range selection, adding a dimension label and a slice count readout.
 
     Attributes:
-        valueChanged: Signal emitted when slider values change, passes (low, high) values
+        valueChanged: Signal emitted when slider values change,
+            passes (low, high) values.
     """
 
-    valueChanged = Signal(int, int)  # Signal to emit low and high values
+    valueChanged = Signal(int, int)
 
     def __init__(
         self,
@@ -42,13 +73,13 @@ class LabeledDoubleRangeSliderWidget(QWidget):
         """Initialize the labeled double range slider widget.
 
         Args:
-            dimension_label: Label text for the slider
-            min_value: Minimum value for the slider range
-            max_value: Maximum value for the slider range
-            enabled: Whether the slider is enabled for interaction
-            readout: Whether to show slice count readout
-            visible: Whether the widget is initially visible
-            show_label: Whether to show the dimension label
+            dimension_label: Label text for the slider.
+            min_value: Minimum value for the slider range.
+            max_value: Maximum value for the slider range.
+            enabled: Whether the slider is enabled for interaction.
+            readout: Whether to show slice count readout.
+            visible: Whether the widget is initially visible.
+            show_label: Whether to show the dimension label.
         """
         super().__init__()
 
@@ -56,31 +87,26 @@ class LabeledDoubleRangeSliderWidget(QWidget):
         self.show_label: bool = show_label
         self.readout_enabled: bool = readout
 
-        # Initialize slider values
         self._low: int = min_value
         self._high: int = max_value
+        self._single_value_mode: bool = False
+        self._updating: bool = False
 
-        # Create the main layout
         layout = QVBoxLayout()
 
-        # Create and add the label if requested
         if show_label:
-            self.label = QLabel(f"{dimension_label} Slider (Range: {min_value}-{max_value})")
+            self.label = QLabel(f"{dimension_label} Slider" f" (Range: {min_value}-{max_value})")
             layout.addWidget(self.label)
 
-        # Create horizontal layout for slider and readout
         slider_layout = QHBoxLayout()
 
-        # Create the slider
-        self.slider = DoubleRangeSlider(
-            dimension_label=dimension_label,
-            min_value=min_value,
-            max_value=max_value,
-            enabled=enabled,
-        )
+        self.slider = QLabeledRangeSlider(Qt.Horizontal)
+        _allow_handle_overlap(self.slider._slider)
+        self.slider.setMinimum(min_value)
+        self.slider.setMaximum(max_value)
+        self.slider.setValue((min_value, max_value))
         slider_layout.addWidget(self.slider)
 
-        # Create the readout label if requested
         if readout:
             self.readout_label = QLabel()
             self.readout_label.setMinimumWidth(80)
@@ -93,20 +119,34 @@ class LabeledDoubleRangeSliderWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
 
-        # Set overall visibility and enabled state
         self.setVisible(visible)
         self.setEnabled(enabled)
 
-        # Connect slider signals
         self.slider.valueChanged.connect(self._on_value_changed)
 
-    def _on_value_changed(self, low: int, high: int) -> None:
-        """Handle value changes from the slider.
+    def _on_value_changed(self, values: tuple[int, ...]) -> None:
+        """Handle value changes from the QLabeledRangeSlider.
 
         Args:
-            low: New low value from the slider
-            high: New high value from the slider
+            values: Tuple of (low, high) from the slider.
         """
+        if self._updating:
+            return
+
+        low, high = int(values[0]), int(values[1])
+
+        if self._single_value_mode and low != high:
+            new_val = low if low != self._low else high
+            self._low = new_val
+            self._high = new_val
+            self._updating = True
+            self.slider.setValue((new_val, new_val))
+            self._updating = False
+            if self.readout_enabled:
+                self.update_readout()
+            self.valueChanged.emit(new_val, new_val)
+            return
+
         self._low = low
         self._high = high
         if self.readout_enabled:
@@ -114,43 +154,30 @@ class LabeledDoubleRangeSliderWidget(QWidget):
         self.valueChanged.emit(low, high)
 
     def update_readout(self) -> None:
-        """
-        Updates the readout and label text for the slider widget.
+        """Update the readout label and dimension label text.
 
-        If readout is enabled and the readout label exists, updates the readout label to display the current slice count.
-        If the label is shown and exists, updates the label to display the dimension label and the current slider range.
-
-        Returns:
-            None
+        If readout is enabled, updates the readout label to display the
+        current slice count.  If the label is shown, updates it with
+        the current slider range.
         """
         if self.readout_enabled and hasattr(self, "readout_label"):
             slice_count = self.slice_count()
             self.readout_label.setText(f"Slices: {slice_count}")
         if self.show_label and hasattr(self, "label"):
-            self.label.setText(f"{self.dimension_label} Slider (Range: {self._low}-{self._high})")
+            self.label.setText(f"{self.dimension_label} Slider" f" (Range: {self._low}-{self._high})")
 
     def update_label(self) -> None:
-        """
-        Updates the label text to display the current slider range.
-
-        If the label is set to be shown and exists as an attribute, this method retrieves
-        the current minimum and maximum values of the slider and updates the label text
-        to reflect the dimension label and the current range.
-
-        Returns:
-            None
-        """
+        """Update the dimension label with current min/max range."""
         if self.show_label and hasattr(self, "label"):
             min_val = self.minimum()
             max_val = self.maximum()
-            self.label.setText(f"{self.dimension_label} Slider (Range: {min_val}-{max_val})")
+            self.label.setText(f"{self.dimension_label} Slider" f" (Range: {min_val}-{max_val})")
 
-    # Slider value methods
     def low(self) -> int:
         """Get the current low value.
 
         Returns:
-            Current low value of the slider
+            Current low value of the slider.
         """
         return self._low
 
@@ -158,16 +185,21 @@ class LabeledDoubleRangeSliderWidget(QWidget):
         """Set the low value of the slider.
 
         Args:
-            low: New low value to set
+            low: New low value to set.
         """
         self._low = low
-        self.slider.setLow(low)
+        self._updating = True
+        self.slider.setValue((low, self._high))
+        self._updating = False
+        if self.readout_enabled:
+            self.update_readout()
+        self.valueChanged.emit(self._low, self._high)
 
     def high(self) -> int:
         """Get the current high value.
 
         Returns:
-            Current high value of the slider
+            Current high value of the slider.
         """
         return self._high
 
@@ -175,42 +207,46 @@ class LabeledDoubleRangeSliderWidget(QWidget):
         """Set the high value of the slider.
 
         Args:
-            high: New high value to set
+            high: New high value to set.
         """
         self._high = high
-        self.slider.setHigh(high)
+        self._updating = True
+        self.slider.setValue((self._low, high))
+        self._updating = False
+        if self.readout_enabled:
+            self.update_readout()
+        self.valueChanged.emit(self._low, self._high)
 
     def slice_count(self) -> int:
-        """Return the number of slices: max - min + 1.
+        """Return the number of slices: high - low + 1.
 
         Returns:
-            Number of slices in the current range
+            Number of slices in the current range.
         """
         return self._high - self._low + 1
 
-    # Widget control methods
     def setEnabled(self, enabled: bool) -> None:
         """Set the enabled state of the widget and its slider.
 
         Args:
-            enabled: Whether the widget should be enabled
+            enabled: Whether the widget should be enabled.
         """
         super().setEnabled(enabled)
         self.slider.setEnabled(enabled)
 
     def setVisible(self, visible: bool) -> None:
-        """Set the visibility of the entire labeled slider widget.
+        """Set the visibility of the entire widget.
 
-        Arg:
-            visible: Whether the widget should be visible
+        Args:
+            visible: Whether the widget should be visible.
         """
         super().setVisible(visible)
 
-    def setTickPosition(self, position) -> None:
+    def setTickPosition(self, position: QSlider.TickPosition) -> None:
         """Set the tick position for the slider.
 
         Args:
-            position: Tick position constant from QSlider
+            position: Tick position constant from QSlider.
         """
         self.slider.setTickPosition(position)
 
@@ -218,7 +254,7 @@ class LabeledDoubleRangeSliderWidget(QWidget):
         """Get the minimum value of the slider.
 
         Returns:
-            Minimum value of the slider range
+            Minimum value of the slider range.
         """
         return self.slider.minimum()
 
@@ -226,7 +262,7 @@ class LabeledDoubleRangeSliderWidget(QWidget):
         """Get the maximum value of the slider.
 
         Returns:
-            Maximum value of the slider range
+            Maximum value of the slider range.
         """
         return self.slider.maximum()
 
@@ -234,7 +270,7 @@ class LabeledDoubleRangeSliderWidget(QWidget):
         """Set the minimum value of the slider.
 
         Args:
-            minimum: New minimum value for the slider
+            minimum: New minimum value for the slider.
         """
         self.slider.setMinimum(minimum)
 
@@ -242,43 +278,50 @@ class LabeledDoubleRangeSliderWidget(QWidget):
         """Set the maximum value of the slider.
 
         Args:
-            maximum: New maximum value for the slider
+            maximum: New maximum value for the slider.
         """
         self.slider.setMaximum(maximum)
 
     def setSingleValueMode(self, enabled: bool) -> None:
-        """Set the slider to single value mode (both handles move together).
+        """Set the slider to single value mode.
+
+        When enabled, both handles move together so only a single
+        value can be selected (e.g. 3-3).
 
         Args:
-            enabled: Whether to enable single value mode
+            enabled: Whether to enable single value mode.
         """
-        self.slider.single_value_mode = enabled
+        self._single_value_mode = enabled
 
-    def setProperty(self, name: str, value) -> None:
+    def setProperty(self, name: str, value: Any) -> None:
         """Override setProperty to handle custom properties.
 
+        Intercepts ``"single_value_mode"`` to toggle single-value
+        mode; all other property names are forwarded to QWidget.
+
         Args:
-            name: Property name
-            value: Property value
+            name: Property name.
+            value: Property value.
         """
         if name == "single_value_mode":
-            self.setSingleValueMode(value)
+            self.setSingleValueMode(bool(value))
         else:
             super().setProperty(name, value)
 
 
-class DoubleRangeSlider(QSlider):
-    """A slider widget with dual handles for selecting a range of values.
+class DoubleRangeSlider(QWidget):
+    """A dual-handle range slider using superqt's QRangeSlider.
 
-    This custom slider allows users to select both minimum and maximum values
-    within a range using two draggable handles. The handles are color-coded:
-    blue for the minimum value and red for the maximum value.
+    This wraps QRangeSlider to provide a backwards-compatible API with
+    named low/high accessors and a valueChanged signal that emits two
+    individual int arguments.
 
     Attributes:
-        valueChanged: Signal emitted when either handle value changes, passes (low, high) values
+        valueChanged: Signal emitted when handle values change,
+            passes (low, high).
     """
 
-    valueChanged = Signal(int, int)  # Signal to emit low and high values
+    valueChanged = Signal(int, int)
 
     def __init__(
         self,
@@ -287,62 +330,60 @@ class DoubleRangeSlider(QSlider):
         max_value: int = 10,
         enabled: bool = True,
     ) -> None:
-        """Initialize the double range slider."""
-        super().__init__(Qt.Horizontal)
+        """Initialize the double range slider.
+
+        Args:
+            dimension_label: Label for the slider dimension.
+            min_value: Minimum value for the slider range.
+            max_value: Maximum value for the slider range.
+            enabled: Whether the slider is enabled for interaction.
+        """
+        super().__init__()
 
         self.dimension_label: str = dimension_label
+        self.single_value_mode: bool = False
         self._low: int = min_value
         self._high: int = max_value
-        self.single_value_mode: bool = False  # Flag to enforce single value selection
+        self._updating: bool = False
 
-        self.setMinimum(min_value)
-        self.setMaximum(max_value)
+        self._slider = QRangeSlider(Qt.Horizontal)
+        _allow_handle_overlap(self._slider)
+        self._slider.setMinimum(min_value)
+        self._slider.setMaximum(max_value)
+        self._slider.setValue((min_value, max_value))
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._slider)
+        self.setLayout(layout)
         self.setEnabled(enabled)
 
-        self.pressed_control: QStyle.SubControl = QStyle.SC_None
-        self.hover_control: QStyle.SubControl = QStyle.SC_None
-        self.click_offset: int = 0
-        self.active_slider: int = 0  # 0 for low, 1 for high, -1 for both
+        self._slider.valueChanged.connect(self._on_values_changed)
 
-    def style(self):
-        """Return a style proxy that exposes QStyle constants as attributes.
+    def _on_values_changed(self, values: tuple[int, ...]) -> None:
+        """Handle value changes from the internal QRangeSlider.
 
-        Tests sometimes access `slider.style().SC_SliderHandle` etc.; the real
-        QStyle object doesn't expose these as attributes on some bindings, so
-        provide a proxy that maps those attribute names to the QStyle constants
-        while delegating methods to the real style object.
+        Args:
+            values: Tuple of (low, high) values from QRangeSlider.
         """
-        real = QApplication.style()
+        if self._updating:
+            return
 
-        class _StyleProxy:
-            def __init__(self, real):
-                self._real = real
+        low, high = int(values[0]), int(values[1])
 
-            def __getattr__(self, name):
-                # Expose common QStyle constants by name so tests and code can
-                # access them via the style() object.
-                const_map = {
-                    "SC_SliderHandle": QStyle.SC_SliderHandle,
-                    "SC_SliderGroove": QStyle.SC_SliderGroove,
-                    "SC_SliderTickmarks": QStyle.SC_SliderTickmarks,
-                    "SC_None": QStyle.SC_None,
-                    "CC_Slider": QStyle.CC_Slider,
-                    "State_Sunken": QStyle.State_Sunken,
-                }
-                if name in const_map:
-                    return const_map[name]
-                return getattr(self._real, name)
+        if self.single_value_mode and low != high:
+            new_val = low if low != self._low else high
+            self._low = new_val
+            self._high = new_val
+            self._updating = True
+            self._slider.setValue((new_val, new_val))
+            self._updating = False
+            self.valueChanged.emit(new_val, new_val)
+            return
 
-            def subControlRect(self, *args, **kwargs):
-                return self._real.subControlRect(*args, **kwargs)
-
-            def hitTestComplexControl(self, *args, **kwargs):
-                return self._real.hitTestComplexControl(*args, **kwargs)
-
-            def sliderValueFromPosition(self, *args, **kwargs):
-                return self._real.sliderValueFromPosition(*args, **kwargs)
-
-        return _StyleProxy(real)
+        self._low = low
+        self._high = high
+        self.valueChanged.emit(low, high)
 
     def low(self) -> int:
         """Get the current low value."""
@@ -351,7 +392,9 @@ class DoubleRangeSlider(QSlider):
     def setLow(self, low: int) -> None:
         """Set the low value of the slider."""
         self._low = low
-        self.update()
+        self._updating = True
+        self._slider.setValue((low, self._high))
+        self._updating = False
         self.valueChanged.emit(self._low, self._high)
 
     def high(self) -> int:
@@ -361,207 +404,48 @@ class DoubleRangeSlider(QSlider):
     def setHigh(self, high: int) -> None:
         """Set the high value of the slider."""
         self._high = high
-        self.update()
+        self._updating = True
+        self._slider.setValue((self._low, high))
+        self._updating = False
         self.valueChanged.emit(self._low, self._high)
 
-    def paintEvent(self, event) -> None:
-        """Custom paint event to draw the slider with dual colored handles."""
-        painter = QPainter(self)
-        style = QApplication.style()
+    def minimum(self) -> int:
+        """Get the minimum value."""
+        return self._slider.minimum()
 
-        # Draw the groove/track
-        opt = QStyleOptionSlider()
-        self.initStyleOption(opt)
-        opt.subControls = QStyle.SC_SliderGroove
-        # Use QSlider.NoTicks via QSlider class for tick comparison
-        if self.tickPosition() != QSlider.NoTicks:
-            opt.subControls |= QStyle.SC_SliderTickmarks
-        style.drawComplexControl(QStyle.CC_Slider, opt, painter, self)
+    def maximum(self) -> int:
+        """Get the maximum value."""
+        return self._slider.maximum()
 
-        # Draw the colored handles
-        for i, value in enumerate([self._low, self._high]):
-            opt = QStyleOptionSlider()
-            self.initStyleOption(opt)
-            opt.subControls = QStyle.SC_SliderHandle
+    def setMinimum(self, minimum: int) -> None:
+        """Set the minimum value."""
+        self._slider.setMinimum(minimum)
 
-            if self.pressed_control and ((self.active_slider == i) or (self.active_slider == -1)):
-                opt.activeSubControls = self.pressed_control
-                opt.state |= QStyle.State_Sunken
-            else:
-                opt.activeSubControls = self.hover_control
+    def setMaximum(self, maximum: int) -> None:
+        """Set the maximum value."""
+        self._slider.setMaximum(maximum)
 
-            opt.sliderPosition = value
-            opt.sliderValue = value
+    def setTickPosition(self, position: QSlider.TickPosition) -> None:
+        """Set the tick position."""
+        self._slider.setTickPosition(position)
 
-            handle_rect = style.subControlRect(QStyle.CC_Slider, opt, QStyle.SC_SliderHandle, self)
+    def tickPosition(self) -> QSlider.TickPosition:
+        """Get the tick position."""
+        return self._slider.tickPosition()
 
-            if not self.isEnabled():
-                painter.fillRect(handle_rect, QColor(128, 128, 128))
-            else:
-                if i == 0:  # Min slider - Blue
-                    painter.fillRect(handle_rect, QColor(0, 100, 255))
-                else:  # Max slider - Red
-                    painter.fillRect(handle_rect, QColor(255, 50, 50))
+    def setOrientation(self, orientation: Qt.Orientation) -> None:
+        """Set the slider orientation."""
+        self._slider.setOrientation(orientation)
 
-            painter.setPen(QColor(0, 0, 0))
-            painter.drawRect(handle_rect)
-
-    def mousePressEvent(self, event) -> None:
-        """Handle mouse press events."""
-        event.accept()
-        style = QApplication.style()
-        button = event.button()
-
-        if button:
-            opt = QStyleOptionSlider()
-            self.initStyleOption(opt)
-
-            # Get handle positions in pixels
-            handle_rects = []
-            for value in [self._low, self._high]:
-                opt.sliderPosition = value
-                handle_rects.append(style.subControlRect(QStyle.CC_Slider, opt, QStyle.SC_SliderHandle, self))
-
-            # When handles overlap, check if click is on the right half of the handle
-            # If yes, prefer the maximum handle
-            click_pos = event.pos().x()
-            if self._low == self._high and handle_rects[0].contains(event.pos()):
-                handle_center = handle_rects[0].center().x()
-                self.active_slider = 1 if click_pos >= handle_center else 0
-                self.pressed_control = QStyle.SC_SliderHandle
-                try:
-                    self.triggerAction(QSlider.SliderMove)
-                    self.setRepeatAction(QSlider.SliderNoAction)
-                except Exception:
-                    from qtpy.QtWidgets import QAbstractSlider
-
-                    self.triggerAction(QAbstractSlider.SliderMove)
-                    self.setRepeatAction(QAbstractSlider.SliderNoAction)
-                self.setSliderDown(True)
-                return
-
-            # Normal handle detection
-            self.active_slider = -1
-            for i, value in enumerate([self._low, self._high]):
-                opt.sliderPosition = value
-                hit = style.hitTestComplexControl(QStyle.CC_Slider, opt, event.pos(), self)
-                if hit == QStyle.SC_SliderHandle:
-                    self.active_slider = i
-                    self.pressed_control = hit
-                    try:
-                        self.triggerAction(QSlider.SliderMove)
-                        self.setRepeatAction(QSlider.SliderNoAction)
-                    except Exception:
-                        from qtpy.QtWidgets import QAbstractSlider
-
-                        self.triggerAction(QAbstractSlider.SliderMove)
-                        self.setRepeatAction(QAbstractSlider.SliderNoAction)
-                    self.setSliderDown(True)
-                    break
-
-            if self.active_slider < 0:
-                self.pressed_control = QStyle.SC_SliderHandle
-                self.click_offset = self.__pixelPosToRangeValue(self.__pick(event.pos()))
-                # Use QAbstractSlider enums via QSlider parent
-                try:
-                    self.triggerAction(QSlider.SliderMove)
-                    self.setRepeatAction(QSlider.SliderNoAction)
-                except Exception:
-                    # Fallback to QAbstractSlider constants if available
-                    from qtpy.QtWidgets import QAbstractSlider
-
-                    self.triggerAction(QAbstractSlider.SliderMove)
-                    self.setRepeatAction(QAbstractSlider.SliderNoAction)
-        else:
-            event.ignore()
-
-    def mouseMoveEvent(self, event) -> None:
-        """Handle mouse move events."""
-        if self.pressed_control != QStyle.SC_SliderHandle:
-            event.ignore()
-            return
-
-        event.accept()
-        new_pos = self.__pixelPosToRangeValue(self.__pick(event.pos()))
-
-        if self.single_value_mode:
-            # In single value mode, both handles move together
-            self._low = new_pos
-            self._high = new_pos
-        elif self.active_slider < 0:
-            # Moving both sliders simultaneously
-            offset = new_pos - self.click_offset
-            self._high += offset
-            self._low += offset
-
-            if self._low < self.minimum():
-                diff = self.minimum() - self._low
-                self._low += diff
-                self._high += diff
-            if self._high > self.maximum():
-                diff = self.maximum() - self._high
-                self._low += diff
-                self._high += diff
-        elif self.active_slider == 0:
-            # Moving low handle - allow it to match high value
-            if new_pos <= self._high:
-                self._low = new_pos
-        else:
-            # Moving high handle - allow it to match low value
-            if new_pos >= self._low:
-                self._high = new_pos
-
-        self.click_offset = new_pos
-        self.update()
-        self.valueChanged.emit(self._low, self._high)
-
-    def mouseReleaseEvent(self, event) -> None:
-        """Handle mouse release events."""
-        if event.button() == Qt.LeftButton:
-            self.pressed_control = QStyle.SC_None
-            self.active_slider = -1
-            self.setSliderDown(False)
-            self.update()
-        event.accept()
-
-    def __pick(self, pt) -> int:
-        """Extract the relevant coordinate from a point."""
-        if self.orientation() == Qt.Horizontal:
-            return pt.x()
-        else:
-            return pt.y()
-
-    def __pixelPosToRangeValue(self, pos: int) -> int:
-        """Convert pixel position to slider value."""
-        opt = QStyleOptionSlider()
-        self.initStyleOption(opt)
-        style = QApplication.style()
-
-        gr = style.subControlRect(QStyle.CC_Slider, opt, QStyle.SC_SliderGroove, self)
-        sr = style.subControlRect(QStyle.CC_Slider, opt, QStyle.SC_SliderHandle, self)
-
-        if self.orientation() == Qt.Horizontal:
-            slider_length = sr.width()
-            slider_min = gr.x()
-            slider_max = gr.right() - slider_length + 1
-        else:
-            slider_length = sr.height()
-            slider_min = gr.y()
-            slider_max = gr.bottom() - slider_length + 1
-
-        return style.sliderValueFromPosition(
-            self.minimum(),
-            self.maximum(),
-            pos - slider_min,
-            slider_max - slider_min,
-            opt.upsideDown,
-        )
+    def orientation(self) -> Qt.Orientation:
+        """Get the slider orientation."""
+        return self._slider.orientation()
 
 
 if __name__ == "__main__":
     import sys
 
-    from qtpy.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
+    from qtpy.QtWidgets import QApplication, QPushButton
 
     def echo(low, high):
         print(f"Low: {low}, High: {high}")
@@ -569,14 +453,13 @@ if __name__ == "__main__":
     def toggle_visibility():
         """Toggle the visibility of the complete labeled slider."""
         labeled_slider.setVisible(not labeled_slider.isVisible())
-        toggle_button.setText(f"{'Show' if not labeled_slider.isVisible() else 'Hide'} Labeled Slider")
+        toggle_button.setText(f"{'Show' if not labeled_slider.isVisible() else 'Hide'}" " Labeled Slider")
 
     app = QApplication(sys.argv)
 
     min_value = 0
     max_value = 9
 
-    # Test the complete labeled slider widget
     labeled_slider = LabeledDoubleRangeSliderWidget(
         dimension_label="Time",
         min_value=min_value,
@@ -588,10 +471,8 @@ if __name__ == "__main__":
     )
     labeled_slider.setLow(min_value)
     labeled_slider.setHigh(max_value)
-    labeled_slider.setTickPosition(QSlider.TicksBelow)
     labeled_slider.valueChanged.connect(echo)
 
-    # Create a main widget
     widget = QWidget()
     layout = QVBoxLayout()
 
@@ -602,7 +483,5 @@ if __name__ == "__main__":
     layout.addWidget(toggle_button)
 
     widget.setLayout(layout)
-
     widget.show()
-    widget.raise_()
-    app.exec_()
+    sys.exit(app.exec_())

--- a/src/napari_czitools/_tests/test_doublerange_slider.py
+++ b/src/napari_czitools/_tests/test_doublerange_slider.py
@@ -1,16 +1,15 @@
 """
 Tests for the _doublerange_slider module.
 
-This module tests both the LabeledDoubleRangeSliderWidget and DoubleRangeSlider classes
-to ensure proper functionality of the dual-handle range slider components.
+This module tests both the LabeledDoubleRangeSliderWidget and DoubleRangeSlider
+classes which now wrap superqt's QLabeledRangeSlider and QRangeSlider.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
-from qtpy.QtCore import QPoint, Qt
-from qtpy.QtGui import QMouseEvent
-from qtpy.QtWidgets import QApplication, QSlider
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication
 
 from napari_czitools._doublerange_slider import (
     DoubleRangeSlider,
@@ -55,14 +54,24 @@ class TestLabeledDoubleRangeSliderWidget:
 
     def test_init_with_label(self):
         """Test initialization with label enabled."""
-        widget = LabeledDoubleRangeSliderWidget(dimension_label="Test", min_value=0, max_value=5, show_label=True)
+        widget = LabeledDoubleRangeSliderWidget(
+            dimension_label="Test",
+            min_value=0,
+            max_value=5,
+            show_label=True,
+        )
 
         assert hasattr(widget, "label")
         assert widget.label.text() == "Test Slider (Range: 0-5)"
 
     def test_init_with_readout(self):
         """Test initialization with readout enabled."""
-        widget = LabeledDoubleRangeSliderWidget(dimension_label="Test", min_value=0, max_value=5, readout=True)
+        widget = LabeledDoubleRangeSliderWidget(
+            dimension_label="Test",
+            min_value=0,
+            max_value=5,
+            readout=True,
+        )
 
         assert hasattr(widget, "readout_label")
         assert "Slices:" in widget.readout_label.text()
@@ -83,10 +92,8 @@ class TestLabeledDoubleRangeSliderWidget:
         """Test low value getter and setter."""
         widget = LabeledDoubleRangeSliderWidget(min_value=0, max_value=10)
 
-        # Test getter
         assert widget.low() == 0
 
-        # Test setter
         widget.setLow(3)
         assert widget.low() == 3
         assert widget._low == 3
@@ -95,10 +102,8 @@ class TestLabeledDoubleRangeSliderWidget:
         """Test high value getter and setter."""
         widget = LabeledDoubleRangeSliderWidget(min_value=0, max_value=10)
 
-        # Test getter
         assert widget.high() == 10
 
-        # Test setter
         widget.setHigh(7)
         assert widget.high() == 7
         assert widget._high == 7
@@ -117,13 +122,13 @@ class TestLabeledDoubleRangeSliderWidget:
 
     def test_update_readout(self):
         """Test readout update functionality."""
-        widget = LabeledDoubleRangeSliderWidget(min_value=0, max_value=10, readout=True)
+        widget = LabeledDoubleRangeSliderWidget(
+            min_value=0, max_value=10, readout=True,
+        )
 
-        # Test initial readout
         initial_text = widget.readout_label.text()
         assert "Slices:" in initial_text
 
-        # Change values and update
         widget.setLow(2)
         widget.setHigh(5)
         widget.update_readout()
@@ -136,17 +141,20 @@ class TestLabeledDoubleRangeSliderWidget:
         widget = LabeledDoubleRangeSliderWidget(readout=False)
 
         # Should not raise an error even without readout_label
-        widget.update_readout()  # Should complete without error
+        widget.update_readout()
 
     def test_update_label(self):
         """Test label update functionality."""
-        widget = LabeledDoubleRangeSliderWidget(dimension_label="Test", min_value=0, max_value=10, show_label=True)
+        widget = LabeledDoubleRangeSliderWidget(
+            dimension_label="Test",
+            min_value=0,
+            max_value=10,
+            show_label=True,
+        )
 
-        # Test initial label
         initial_text = widget.label.text()
         assert "Test Slider (Range:" in initial_text
 
-        # Update label
         widget.update_label()
 
         min_val = widget.minimum()
@@ -159,45 +167,41 @@ class TestLabeledDoubleRangeSliderWidget:
         widget = LabeledDoubleRangeSliderWidget(show_label=False)
 
         # Should not raise an error even without label
-        widget.update_label()  # Should complete without error
+        widget.update_label()
 
     def test_value_changed_signal(self):
         """Test valueChanged signal emission."""
         widget = LabeledDoubleRangeSliderWidget(min_value=0, max_value=10)
 
-        # Connect signal to mock
         signal_mock = MagicMock()
         widget.valueChanged.connect(signal_mock)
 
-        # Trigger value change through slider
-        widget.slider.setLow(3)
+        # Trigger value change through setLow
+        widget.setLow(3)
 
-        # Verify signal was emitted
         signal_mock.assert_called_with(3, 10)
 
     def test_on_value_changed(self):
         """Test internal value change handler."""
-        widget = LabeledDoubleRangeSliderWidget(min_value=0, max_value=10, readout=True, show_label=True)
+        widget = LabeledDoubleRangeSliderWidget(
+            min_value=0, max_value=10, readout=True, show_label=True,
+        )
 
-        # Mock the signal emission
         signal_mock = MagicMock()
         widget.valueChanged.connect(signal_mock)
 
-        # Call the internal handler
-        widget._on_value_changed(2, 8)
+        # Simulate an internal value change from the slider
+        widget._on_value_changed((2, 8))
 
-        # Verify values were updated
         assert widget._low == 2
         assert widget._high == 8
 
-        # Verify signal was emitted
         signal_mock.assert_called_with(2, 8)
 
     def test_widget_control_methods(self):
         """Test widget control methods (setEnabled, setVisible, etc.)."""
         widget = LabeledDoubleRangeSliderWidget()
 
-        # Test setEnabled
         widget.setEnabled(False)
         assert not widget.isEnabled()
         assert not widget.slider.isEnabled()
@@ -206,35 +210,56 @@ class TestLabeledDoubleRangeSliderWidget:
         assert widget.isEnabled()
         assert widget.slider.isEnabled()
 
-        # Test setVisible
         widget.setVisible(False)
         assert not widget.isVisible()
 
         widget.setVisible(True)
         assert widget.isVisible()
 
-    def test_tick_position(self):
-        """Test tick position setting."""
-        widget = LabeledDoubleRangeSliderWidget()
-
-        # Test setting tick position
-        widget.setTickPosition(QSlider.TicksBelow)
-        # Note: We can't easily test the actual tick position without accessing internal Qt state
-
     def test_minimum_maximum_methods(self):
         """Test minimum and maximum value methods."""
         widget = LabeledDoubleRangeSliderWidget(min_value=5, max_value=15)
 
-        # Test getters
         assert widget.minimum() == 5
         assert widget.maximum() == 15
 
-        # Test setters
         widget.setMinimum(2)
         widget.setMaximum(20)
 
         assert widget.minimum() == 2
         assert widget.maximum() == 20
+
+    def test_single_value_mode(self):
+        """Test single value mode via setProperty and setSingleValueMode."""
+        widget = LabeledDoubleRangeSliderWidget(min_value=0, max_value=10)
+
+        # Not enabled by default
+        assert widget._single_value_mode is False
+
+        # Enable via setSingleValueMode
+        widget.setSingleValueMode(True)
+        assert widget._single_value_mode is True
+
+        # Disable
+        widget.setSingleValueMode(False)
+        assert widget._single_value_mode is False
+
+        # Enable via setProperty
+        widget.setProperty("single_value_mode", True)
+        assert widget._single_value_mode is True
+
+    def test_single_value_mode_snaps_handles(self):
+        """Test that single value mode snaps both handles together."""
+        widget = LabeledDoubleRangeSliderWidget(min_value=0, max_value=10)
+        widget.setLow(0)
+        widget.setHigh(10)
+        widget.setSingleValueMode(True)
+
+        # Simulate a change where user moves low handle
+        widget._on_value_changed((5, 10))
+
+        assert widget._low == 5
+        assert widget._high == 5
 
 
 class TestDoubleRangeSlider:
@@ -271,10 +296,8 @@ class TestDoubleRangeSlider:
         """Test low value getter and setter."""
         slider = DoubleRangeSlider(min_value=0, max_value=10)
 
-        # Test getter
         assert slider.low() == 0
 
-        # Test setter with signal emission
         signal_mock = MagicMock()
         slider.valueChanged.connect(signal_mock)
 
@@ -286,10 +309,8 @@ class TestDoubleRangeSlider:
         """Test high value getter and setter."""
         slider = DoubleRangeSlider(min_value=0, max_value=10)
 
-        # Test getter
         assert slider.high() == 10
 
-        # Test setter with signal emission
         signal_mock = MagicMock()
         slider.valueChanged.connect(signal_mock)
 
@@ -297,491 +318,94 @@ class TestDoubleRangeSlider:
         assert slider.high() == 7
         signal_mock.assert_called_with(0, 7)
 
-    def test_paint_event(self):
-        """Test paint event handling."""
-        slider = DoubleRangeSlider()
-        slider.setGeometry(0, 0, 200, 30)  # Set a size for the slider
-
-        # Create a mock paint event and patch both QPainter and QApplication.style
-        with (
-            patch("napari_czitools._doublerange_slider.QPainter") as mock_painter,
-            patch("napari_czitools._doublerange_slider.QApplication.style") as mock_style,
-        ):
-
-            mock_painter_instance = MagicMock()
-            mock_painter.return_value = mock_painter_instance
-
-            mock_style_instance = MagicMock()
-            mock_style.return_value = mock_style_instance
-
-            # Create a mock paint event
-            mock_event = MagicMock()
-
-            # Call paintEvent - should not raise an exception
-            slider.paintEvent(mock_event)
-
-            # Verify QPainter was instantiated
-            mock_painter.assert_called_once_with(slider)
-            # Verify that drawing methods were called
-            assert mock_style_instance.drawComplexControl.called
-
-    def test_mouse_press_event_normal_handles(self):
-        """Test mouse press event for normal handle detection."""
+    def test_minimum_maximum(self):
+        """Test minimum and maximum getters and setters."""
         slider = DoubleRangeSlider(min_value=0, max_value=100)
-        slider.setGeometry(0, 0, 200, 30)  # Set a size for the slider
 
-        # Create a mock mouse event
-        with patch("napari_czitools._doublerange_slider.QApplication.style") as mock_style:
-            mock_style_instance = MagicMock()
-            mock_style.return_value = mock_style_instance
+        assert slider.minimum() == 0
+        assert slider.maximum() == 100
 
-            # Mock hit test to return handle hit
-            mock_style_instance.hitTestComplexControl.return_value = mock_style_instance.SC_SliderHandle
+        slider.setMinimum(10)
+        slider.setMaximum(50)
 
-            # Create mouse press event
-            event = QMouseEvent(
-                QMouseEvent.MouseButtonPress, QPoint(50, 15), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier
-            )
+        assert slider.minimum() == 10
+        assert slider.maximum() == 50
 
-            # Call the method
-            slider.mousePressEvent(event)
+    def test_single_value_mode_attribute(self):
+        """Test the single_value_mode attribute."""
+        slider = DoubleRangeSlider(min_value=0, max_value=10)
 
-            # Verify event was accepted
-            assert event.isAccepted()
+        assert slider.single_value_mode is False
 
-    def test_mouse_press_event_overlapping_handles(self):
-        """Test mouse press event when handles overlap."""
-        slider = DoubleRangeSlider(min_value=0, max_value=100)
-        slider._low = 50
-        slider._high = 50  # Overlapping handles
-        slider.setGeometry(0, 0, 200, 30)
+        slider.single_value_mode = True
+        assert slider.single_value_mode is True
 
-        with patch("napari_czitools._doublerange_slider.QApplication.style") as mock_style:
-            mock_style_instance = MagicMock()
-            mock_style.return_value = mock_style_instance
+    def test_single_value_mode_snaps_via_signal(self):
+        """Test that single value mode snaps handles together on change."""
+        slider = DoubleRangeSlider(min_value=0, max_value=10)
+        slider.setLow(0)
+        slider.setHigh(10)
+        slider.single_value_mode = True
 
-            # Mock handle rectangle
-            mock_rect = MagicMock()
-            mock_rect.contains.return_value = True
-            mock_rect.center.return_value.x.return_value = 100
-            mock_style_instance.subControlRect.return_value = mock_rect
+        signal_mock = MagicMock()
+        slider.valueChanged.connect(signal_mock)
 
-            # Create mouse press event (right side of handle - should select max handle)
-            event = QMouseEvent(
-                QMouseEvent.MouseButtonPress,
-                QPoint(105, 15),  # Right of center
-                Qt.LeftButton,
-                Qt.LeftButton,
-                Qt.NoModifier,
-            )
+        # Simulate internal change where low moved to 5
+        slider._on_values_changed((5, 10))
 
-            slider.mousePressEvent(event)
+        assert slider.low() == 5
+        assert slider.high() == 5
+        signal_mock.assert_called_with(5, 5)
 
-            # Should select max handle (index 1)
-            assert slider.active_slider == 1
-
-    def test_mouse_move_event_low_handle(self):
-        """Test mouse move event for low handle."""
-        slider = DoubleRangeSlider(min_value=0, max_value=100)
-        slider.pressed_control = slider.style().SC_SliderHandle
-        slider.active_slider = 0  # Low handle
-        slider.setGeometry(0, 0, 200, 30)
-
-        with patch.object(slider, "_DoubleRangeSlider__pixelPosToRangeValue", return_value=25):
-            # Create mouse move event
-            event = QMouseEvent(QMouseEvent.MouseMove, QPoint(50, 15), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
-
-            signal_mock = MagicMock()
-            slider.valueChanged.connect(signal_mock)
-
-            slider.mouseMoveEvent(event)
-
-            # Low value should be updated if new_pos <= high
-            assert slider._low == 25
-            signal_mock.assert_called()
-
-    def test_mouse_move_event_high_handle(self):
-        """Test mouse move event for high handle."""
-        slider = DoubleRangeSlider(min_value=0, max_value=100)
-        slider.pressed_control = slider.style().SC_SliderHandle
-        slider.active_slider = 1  # High handle
-        slider.setGeometry(0, 0, 200, 30)
-
-        with patch.object(slider, "_DoubleRangeSlider__pixelPosToRangeValue", return_value=75):
-            # Create mouse move event
-            event = QMouseEvent(QMouseEvent.MouseMove, QPoint(150, 15), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
-
-            signal_mock = MagicMock()
-            slider.valueChanged.connect(signal_mock)
-
-            slider.mouseMoveEvent(event)
-
-            # High value should be updated if new_pos >= low
-            assert slider._high == 75
-            signal_mock.assert_called()
-
-    def test_mouse_move_event_both_handles(self):
-        """Test mouse move event for both handles simultaneously."""
-        slider = DoubleRangeSlider(min_value=0, max_value=100)
-        slider.pressed_control = slider.style().SC_SliderHandle
-        slider.active_slider = -1  # Both handles
-        slider.click_offset = 50
-        slider._low = 20
-        slider._high = 80
-        slider.setGeometry(0, 0, 200, 30)
-
-        with patch.object(slider, "_DoubleRangeSlider__pixelPosToRangeValue", return_value=60):
-            # Create mouse move event
-            event = QMouseEvent(QMouseEvent.MouseMove, QPoint(120, 15), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
-
-            signal_mock = MagicMock()
-            slider.valueChanged.connect(signal_mock)
-
-            original_low = slider._low
-            original_high = slider._high
-
-            slider.mouseMoveEvent(event)
-
-            # Both handles should move by the offset
-            offset = 60 - 50  # new_pos - click_offset
-            assert slider._low == original_low + offset
-            assert slider._high == original_high + offset
-            signal_mock.assert_called()
-
-    def test_mouse_move_event_boundary_constraints(self):
-        """Test mouse move event with boundary constraints."""
-        slider = DoubleRangeSlider(min_value=0, max_value=100)
-        slider.pressed_control = slider.style().SC_SliderHandle
-        slider.active_slider = -1  # Both handles
-        slider.click_offset = 50
-        slider._low = 10
-        slider._high = 90
-        slider.setGeometry(0, 0, 200, 30)
-
-        # Test moving beyond maximum
-        with patch.object(slider, "_DoubleRangeSlider__pixelPosToRangeValue", return_value=70):
-            event = QMouseEvent(QMouseEvent.MouseMove, QPoint(140, 15), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
-
-            slider.mouseMoveEvent(event)
-
-            # Should adjust to stay within bounds
-            offset = 70 - 50  # 20
-            expected_high = 90 + offset  # 110, but clamped
-            if expected_high > 100:
-                diff = expected_high - 100
-                expected_low = 10 + offset - diff
-                expected_high = 100
-                assert slider._low == expected_low
-                assert slider._high == expected_high
-
-    def test_mouse_release_event(self):
-        """Test mouse release event."""
-        slider = DoubleRangeSlider()
-        slider.pressed_control = slider.style().SC_SliderHandle
-        slider.active_slider = 0
-
-        # Create mouse release event
-        event = QMouseEvent(QMouseEvent.MouseButtonRelease, QPoint(50, 15), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
-
-        slider.mouseReleaseEvent(event)
-
-        # Should reset pressed state
-        assert slider.pressed_control == slider.style().SC_None
-        assert slider.active_slider == -1
-        assert event.isAccepted()
-
-    def test_pick_horizontal(self):
-        """Test __pick method for horizontal orientation."""
+    def test_orientation(self):
+        """Test orientation getter and setter."""
         slider = DoubleRangeSlider()
 
-        point = QPoint(50, 25)
-        result = slider._DoubleRangeSlider__pick(point)
+        assert slider.orientation() == Qt.Horizontal
 
-        # Should return x coordinate for horizontal slider
-        assert result == 50
-
-    def test_pick_vertical(self):
-        """Test __pick method for vertical orientation."""
-        slider = DoubleRangeSlider()
         slider.setOrientation(Qt.Vertical)
+        assert slider.orientation() == Qt.Vertical
 
-        point = QPoint(50, 25)
-        result = slider._DoubleRangeSlider__pick(point)
+    def test_value_changed_signal_on_set_low(self):
+        """Test that valueChanged signal is emitted when low is set."""
+        slider = DoubleRangeSlider(min_value=0, max_value=10)
 
-        # Should return y coordinate for vertical slider
-        assert result == 25
+        signal_mock = MagicMock()
+        slider.valueChanged.connect(signal_mock)
 
-    def test_pixel_pos_to_range_value(self):
-        """Test __pixelPosToRangeValue method."""
-        slider = DoubleRangeSlider(min_value=0, max_value=100)
-        slider.setGeometry(0, 0, 200, 30)
+        slider.setLow(4)
+        signal_mock.assert_called_with(4, 10)
 
-        with patch("napari_czitools._doublerange_slider.QApplication.style") as mock_style:
-            mock_style_instance = MagicMock()
-            mock_style.return_value = mock_style_instance
+    def test_value_changed_signal_on_set_high(self):
+        """Test that valueChanged signal is emitted when high is set."""
+        slider = DoubleRangeSlider(min_value=0, max_value=10)
 
-            # Mock the style calculations
-            mock_style_instance.sliderValueFromPosition.return_value = 50
+        signal_mock = MagicMock()
+        slider.valueChanged.connect(signal_mock)
 
-            # Mock rectangles
-            mock_groove_rect = MagicMock()
-            mock_groove_rect.x.return_value = 10
-            mock_groove_rect.right.return_value = 190
+        slider.setHigh(6)
+        signal_mock.assert_called_with(0, 6)
 
-            mock_handle_rect = MagicMock()
-            mock_handle_rect.width.return_value = 20
+    def test_equal_low_high_values(self):
+        """Test setting low and high to the same value (single selection)."""
+        slider = DoubleRangeSlider(min_value=0, max_value=10)
 
-            mock_style_instance.subControlRect.side_effect = [mock_groove_rect, mock_handle_rect]
+        slider.setLow(5)
+        slider.setHigh(5)
 
-            result = slider._DoubleRangeSlider__pixelPosToRangeValue(100)
+        assert slider.low() == 5
+        assert slider.high() == 5
 
-            # Should call sliderValueFromPosition with correct parameters
-            mock_style_instance.sliderValueFromPosition.assert_called_once()
-            assert result == 50
+    def test_enabled_disabled(self):
+        """Test enable/disable state."""
+        slider = DoubleRangeSlider(min_value=0, max_value=10, enabled=True)
+        assert slider.isEnabled() is True
 
-    def test_mouse_move_event_ignored_when_not_pressed(self):
-        """Test that mouse move event is ignored when no control is pressed."""
-        slider = DoubleRangeSlider()
-        slider.pressed_control = slider.style().SC_None  # No control pressed
-
-        event = QMouseEvent(QMouseEvent.MouseMove, QPoint(50, 15), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
-
-        slider.mouseMoveEvent(event)
-
-        # Event should be ignored
-        assert not event.isAccepted()
-
-    def test_low_handle_movement_constraint(self):
-        """Test that low handle cannot move beyond high handle."""
-        slider = DoubleRangeSlider(min_value=0, max_value=100)
-        slider._low = 30
-        slider._high = 70
-        slider.pressed_control = slider.style().SC_SliderHandle
-        slider.active_slider = 0  # Low handle
-
-        with patch.object(
-            slider, "_DoubleRangeSlider__pixelPosToRangeValue", return_value=80
-        ):  # Try to move beyond high
-            event = QMouseEvent(QMouseEvent.MouseMove, QPoint(160, 15), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
-
-            original_low = slider._low
-            slider.mouseMoveEvent(event)
-
-            # Low should not change because new_pos (80) > high (70)
-            assert slider._low == original_low
-
-    def test_high_handle_movement_constraint(self):
-        """Test that high handle cannot move beyond low handle."""
-        slider = DoubleRangeSlider(min_value=0, max_value=100)
-        slider._low = 30
-        slider._high = 70
-        slider.pressed_control = slider.style().SC_SliderHandle
-        slider.active_slider = 1  # High handle
-
-        with patch.object(
-            slider, "_DoubleRangeSlider__pixelPosToRangeValue", return_value=20
-        ):  # Try to move beyond low
-            event = QMouseEvent(QMouseEvent.MouseMove, QPoint(40, 15), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
-
-            original_high = slider._high
-            slider.mouseMoveEvent(event)
-
-            # High should not change because new_pos (20) < low (30)
-            assert slider._high == original_high
-
-    def test_paint_event_with_tick_marks(self):
-        """Test paint event with tick marks enabled."""
-        slider = DoubleRangeSlider()
-        slider.setTickPosition(QSlider.TicksBelow)  # Enable tick marks
-        slider.setGeometry(0, 0, 200, 30)
-
-        with (
-            patch("napari_czitools._doublerange_slider.QPainter") as mock_painter,
-            patch("napari_czitools._doublerange_slider.QApplication.style") as mock_style,
-        ):
-
-            mock_painter_instance = MagicMock()
-            mock_painter.return_value = mock_painter_instance
-
-            mock_style_instance = MagicMock()
-            mock_style.return_value = mock_style_instance
-
-            mock_event = MagicMock()
-
-            slider.paintEvent(mock_event)
-
-            # Verify QPainter was instantiated
-            mock_painter.assert_called_once_with(slider)
-
-    def test_paint_event_pressed_control_states(self):
-        """Test paint event with different pressed control states."""
-        slider = DoubleRangeSlider()
-        slider.setGeometry(0, 0, 200, 30)
-
-        # Test with pressed control and active slider
-        slider.pressed_control = slider.style().SC_SliderHandle
-        slider.active_slider = 0
-
-        with (
-            patch("napari_czitools._doublerange_slider.QPainter") as mock_painter,
-            patch("napari_czitools._doublerange_slider.QApplication.style") as mock_style,
-        ):
-
-            mock_painter_instance = MagicMock()
-            mock_painter.return_value = mock_painter_instance
-
-            mock_style_instance = MagicMock()
-            mock_style.return_value = mock_style_instance
-
-            mock_event = MagicMock()
-
-            slider.paintEvent(mock_event)
-
-            # Verify QPainter was instantiated
-            mock_painter.assert_called_once_with(slider)
-
-    def test_paint_event_disabled_state(self):
-        """Test paint event when slider is disabled."""
-        slider = DoubleRangeSlider()
         slider.setEnabled(False)
-        slider.setGeometry(0, 0, 200, 30)
+        assert slider.isEnabled() is False
 
-        with (
-            patch("napari_czitools._doublerange_slider.QPainter") as mock_painter,
-            patch("napari_czitools._doublerange_slider.QApplication.style") as mock_style,
-        ):
-
-            mock_painter_instance = MagicMock()
-            mock_painter.return_value = mock_painter_instance
-
-            mock_style_instance = MagicMock()
-            mock_style.return_value = mock_style_instance
-
-            mock_event = MagicMock()
-
-            slider.paintEvent(mock_event)
-
-            # Verify QPainter was instantiated
-            mock_painter.assert_called_once_with(slider)
-
-    def test_mouse_press_event_no_button(self):
-        """Test mouse press event when no button is pressed."""
-        slider = DoubleRangeSlider()
-
-        # Create mouse press event with no button
-        event = QMouseEvent(
-            QMouseEvent.MouseButtonPress, QPoint(50, 15), Qt.NoButton, Qt.NoButton, Qt.NoModifier  # No button pressed
-        )
-
-        slider.mousePressEvent(event)
-
-        # Event should be ignored
-        assert not event.isAccepted()
-
-    def test_mouse_press_event_no_handle_hit(self):
-        """Test mouse press event when no handle is hit."""
-        slider = DoubleRangeSlider(min_value=0, max_value=100)
-        slider.setGeometry(0, 0, 200, 30)
-
-        with patch("napari_czitools._doublerange_slider.QApplication.style") as mock_style:
-            mock_style_instance = MagicMock()
-            mock_style.return_value = mock_style_instance
-
-            # Mock hit test to return no handle hit
-            mock_style_instance.hitTestComplexControl.return_value = mock_style_instance.SC_None
-
-            with patch.object(slider, "_DoubleRangeSlider__pixelPosToRangeValue", return_value=50):
-                event = QMouseEvent(
-                    QMouseEvent.MouseButtonPress, QPoint(100, 15), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier
-                )
-
-                slider.mousePressEvent(event)
-
-                # Should set click_offset when no handle is hit
-                assert slider.click_offset == 50
-                assert slider.active_slider < 0
-
-    def test_mouse_move_event_boundary_constraints_minimum(self):
-        """Test mouse move event with boundary constraints at minimum."""
-        slider = DoubleRangeSlider(min_value=0, max_value=100)
-        slider.pressed_control = slider.style().SC_SliderHandle
-        slider.active_slider = -1  # Both handles
-        slider.click_offset = 30
-        slider._low = 10
-        slider._high = 40
-
-        # Test moving beyond minimum
-        with patch.object(slider, "_DoubleRangeSlider__pixelPosToRangeValue", return_value=5):  # Would move low to -15
-            event = QMouseEvent(QMouseEvent.MouseMove, QPoint(10, 15), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
-
-            original_range = slider._high - slider._low
-            slider.mouseMoveEvent(event)
-
-            # Should adjust to stay within bounds
-            assert slider._low >= 0  # Should not go below minimum
-            assert slider._high - slider._low == original_range  # Range should be preserved
-
-    def test_vertical_orientation_pick(self):
-        """Test __pick method for vertical orientation."""
-        slider = DoubleRangeSlider()
-        slider.setOrientation(Qt.Vertical)
-
-        point = QPoint(50, 25)
-        result = slider._DoubleRangeSlider__pick(point)
-
-        # Should return y coordinate for vertical slider
-        assert result == 25
-
-    def test_pixel_pos_to_range_value_vertical(self):
-        """Test __pixelPosToRangeValue method for vertical orientation."""
-        slider = DoubleRangeSlider(min_value=0, max_value=100)
-        slider.setOrientation(Qt.Vertical)
-        slider.setGeometry(0, 0, 30, 200)
-
-        with patch("napari_czitools._doublerange_slider.QApplication.style") as mock_style:
-            mock_style_instance = MagicMock()
-            mock_style.return_value = mock_style_instance
-
-            # Mock the style calculations for vertical
-            mock_style_instance.sliderValueFromPosition.return_value = 50
-
-            # Mock rectangles for vertical orientation
-            mock_groove_rect = MagicMock()
-            mock_groove_rect.y.return_value = 10
-            mock_groove_rect.bottom.return_value = 190
-
-            mock_handle_rect = MagicMock()
-            mock_handle_rect.height.return_value = 20
-
-            mock_style_instance.subControlRect.side_effect = [mock_groove_rect, mock_handle_rect]
-
-            result = slider._DoubleRangeSlider__pixelPosToRangeValue(100)
-
-            # Should call sliderValueFromPosition with correct parameters
-            mock_style_instance.sliderValueFromPosition.assert_called_once()
-            assert result == 50
-
-    def test_mouse_move_event_boundary_maximum_adjustment(self):
-        """Test mouse move event boundary adjustment when exceeding maximum."""
-        slider = DoubleRangeSlider(min_value=0, max_value=100)
-        slider.pressed_control = slider.style().SC_SliderHandle
-        slider.active_slider = -1  # Both handles
-        slider.click_offset = 70
-        slider._low = 80
-        slider._high = 95
-
-        # Test moving beyond maximum
-        with patch.object(
-            slider, "_DoubleRangeSlider__pixelPosToRangeValue", return_value=90
-        ):  # Would move high to 115
-            event = QMouseEvent(QMouseEvent.MouseMove, QPoint(180, 15), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
-
-            original_range = slider._high - slider._low
-            slider.mouseMoveEvent(event)
-
-            # Should adjust to stay within bounds
-            assert slider._high <= 100  # Should not exceed maximum
-            assert slider._high - slider._low == original_range  # Range should be preserved
+        slider.setEnabled(True)
+        assert slider.isEnabled() is True
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{310,311,312,313}-{linux,macos,windows}
+envlist = py{311,312,313}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
-    3.10: py310
     3.11: py311
     3.12: py312
     3.13: py313


### PR DESCRIPTION
## Summary

This PR replaces the custom hand-coded `DoubleRangeSlider` QSlider subclass (~600 lines of manual `paintEvent`/`mousePressEvent`/`mouseMoveEvent`) with thin wrappers around **superqt**'s `QLabeledRangeSlider` and `QRangeSlider`. It also updates CI workflow actions to Node.js 24-compatible versions.

## Problem

- The custom dual-handle slider was difficult to maintain (~600 lines of low-level Qt painting and mouse-handling code).
- `superqt` was already a declared dependency but its range slider widgets were not used.
- superqt's `QRangeSlider` enforces a minimum gap of `singleStep()` (default 1) between handles, which prevented single-frame extraction (e.g. both handles at value 4).
- GitHub Actions `actions/checkout@v4`, `actions/setup-python@v5`, and `codecov/codecov-action@v3` use deprecated or soon-to-be-deprecated Node.js runtimes (16/20).

## Changes

### Slider refactoring

- **Rewrote** `src/napari_czitools/_doublerange_slider.py`:
  - `LabeledDoubleRangeSliderWidget` now wraps `QLabeledRangeSlider` from superqt with a dimension label + slice readout.
  - `DoubleRangeSlider` now wraps `QRangeSlider` from superqt with `low()`/`high()`/`setLow()`/`setHigh()` API.
  - Added `_allow_handle_overlap()` helper that monkey-patches superqt's internal `_neighbor_bound` method to use zero gap, enabling single-frame extraction (both handles at same value).
  - Full type annotations (`tuple[int, ...]`, `QSlider.TickPosition`, `Qt.Orientation`, `Any`).
  - Public API unchanged — all consumers in `_widget.py` work without modification.
- **Rewrote** `src/napari_czitools/_tests/test_doublerange_slider.py`:
  - 31 tests covering the new wrapper classes (no more mock painting/mouse tests).
  - Includes single-value mode and handle overlap tests.

### CI workflow updates (Node.js 24)

- **Updated** `.github/workflows/test_and_deploy_pypi.yml`:
  - `actions/checkout` v4 → v6 (Node.js 24)
  - `actions/setup-python` v5 → v6 (Node.js 24)
  - `codecov/codecov-action` v3 → v5 (Node.js 20, replaces deprecated Node.js 16)
- **Updated** `.github/workflows/test_and_deploy_testpypi.yml`:
  - Same action version bumps as above.
- `tlambert03/setup-qt-libs@v1` and `aganders3/headless-gui@v2` remain unchanged (already on Node.js 20, no newer major version available).

### Documentation

- **Updated** `README.md` with superqt slider descriptions and compatibility notes.
- **Updated** `.github/copilot-instructions.md` with slider refactoring guidance, handle-overlap patch notes, and preference to use the superqt wrapper API.

## Validation

Executed in conda environment `smartmic` (Python 3.12.12, PyQt5 5.15.11):

- `python -m pytest src/napari_czitools/_tests/test_doublerange_slider.py src/napari_czitools/_tests/test_scene_constraint.py src/napari_czitools/_tests/test_widget.py src/napari_czitools/_tests/test_widget_comprehensive.py -v`

Result:

- `54 passed, 16 warnings in 12.35s`

## Notes

- Warnings are existing Qt/pydantic deprecation warnings and not introduced by this PR.
- `superqt` is already a declared dependency in `pyproject.toml` — no new dependencies added.
- The handle-overlap patch (`_allow_handle_overlap`) is applied at construction time to every slider instance and only overrides one internal method on superqt's `_GenericRangeSlider`.
